### PR TITLE
-removed commented js functions for theme switching in app.razor.

### DIFF
--- a/BlazorLayout/BlazorLayout.Client/Layout/GridLayout.razor
+++ b/BlazorLayout/BlazorLayout.Client/Layout/GridLayout.razor
@@ -11,15 +11,8 @@
 
             <h5>Navbar content here</h5>
 
-            <div class="dropdown" data-bs-theme="light">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButtonLight" data-bs-toggle="dropdown" aria-expanded="false">
-                    Theme
-                </button>
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButtonLight">
-                    <li><a @onclick="@(() => SwitchTheme("light"))" class="dropdown-item" href="#">Light</a></li>
-                    <li><a @onclick="@(() => SwitchTheme("dark"))" class="dropdown-item" href="#">Dark</a></li>
-                    @* <li><a @onclick="@(() => SwitchTheme("auto"))" class="dropdown-item" href="#">Auto</a></li> *@
-                </ul>
+            <div class="form-check form-switch" @onclick="SwitchTheme">
+                <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault">
             </div>
 
             <div>
@@ -77,20 +70,8 @@
         collapseRightbar = !collapseRightbar;
     }
 
-    private async void SwitchTheme(string mode)
+    private async void SwitchTheme()
     {
-        if (mode == "dark")
-        {
-            await JSRuntime.InvokeVoidAsync("darkMode");
-        }
-        else if (mode == "light")
-        {
-            await JSRuntime.InvokeVoidAsync("lightMode");
-        } 
-        // else
-        // {
-        //     await JSRuntime.InvokeVoidAsync("auto");
-        // }
-    }
-
+        await JSRuntime.InvokeVoidAsync("switchTheme");
+    } 
     }

--- a/BlazorLayout/BlazorLayout/Components/App.razor
+++ b/BlazorLayout/BlazorLayout/Components/App.razor
@@ -2,7 +2,7 @@
 <html id="html1" lang="en">
 
 <head>
-    <meta charset="utf-8" data-bs-theme-value="auto" />
+    <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
@@ -12,180 +12,17 @@
     <HeadOutlet @rendermode="InteractiveWebAssembly" />
 </head>
 
-<body>
+<body data-bs-theme="light">
 
     <Routes @rendermode="InteractiveWebAssembly" />
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="_framework/blazor.web.js"></script>
     <script>
-        function darkMode() {
-            var element = document.getElementById("html1");
-            element.setAttribute("data-bs-theme", "dark");
+        function switchTheme() {
+            var element = document.body;
+            element.dataset.bsTheme = 
+            element.dataset.bsTheme == "light" ? "dark" : "light"
         }
-        
-        function lightMode() {
-            var element = document.getElementById("html1");
-            element.setAttribute("data-bs-theme", "light");
-        }
-        
-        // function auto() {
-        //     checkAuto();
-        // }
-
-    </script>
-
-    <script>
-        // function checkAuto() {
-        //     (() => {
-        //         'use strict'
-
-        //         const getStoredTheme = () => localStorage.getItem('theme')
-        //         const setStoredTheme = theme => localStorage.setItem('theme', theme)
-
-        //         const getPreferredTheme = () => {
-        //             const storedTheme = getStoredTheme()
-        //             if (storedTheme) {
-        //                 return storedTheme
-        //             }
-
-        //             return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-        //         }
-
-        //         const setTheme = theme => {
-        //             if (theme === 'auto') {
-        //                 document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
-        //             } else {
-        //                 document.documentElement.setAttribute('data-bs-theme', theme)
-        //             }
-        //         }
-
-        //         setTheme(getPreferredTheme())
-
-        //         const showActiveTheme = (theme, focus = false) => {
-        //             const themeSwitcher = document.querySelector('#bd-theme')
-
-        //             if (!themeSwitcher) {
-        //                 return
-        //             }
-
-        //             const themeSwitcherText = document.querySelector('#bd-theme-text')
-        //             const activeThemeIcon = document.querySelector('.theme-icon-active use')
-        //             const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
-        //             const svgOfActiveBtn = btnToActive.querySelector('svg use').getAttribute('href')
-
-        //             document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
-        //                 element.classList.remove('active')
-        //                 element.setAttribute('aria-pressed', 'false')
-        //             })
-
-        //             btnToActive.classList.add('active')
-        //             btnToActive.setAttribute('aria-pressed', 'true')
-        //             activeThemeIcon.setAttribute('href', svgOfActiveBtn)
-        //             const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
-        //             themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
-
-        //             if (focus) {
-        //                 themeSwitcher.focus()
-        //             }
-        //         }
-
-        //         window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-        //             const storedTheme = getStoredTheme()
-        //             if (storedTheme !== 'light' && storedTheme !== 'dark') {
-        //                 setTheme(getPreferredTheme())
-        //             }
-        //         })
-
-        //         window.addEventListener('DOMContentLoaded', () => {
-        //             showActiveTheme(getPreferredTheme())
-
-        //             document.querySelectorAll('[data-bs-theme-value]')
-        //                 .forEach(toggle => {
-        //                     toggle.addEventListener('click', () => {
-        //                         const theme = toggle.getAttribute('data-bs-theme-value')
-        //                         setStoredTheme(theme)
-        //                         setTheme(theme)
-        //                         showActiveTheme(theme, true)
-        //                     })
-        //                 })
-        //         })
-        //     })()
-        // }
-
-        // (() => {
-        //     'use strict'
-
-        //     const getStoredTheme = () => localStorage.getItem('theme')
-        //     const setStoredTheme = theme => localStorage.setItem('theme', theme)
-
-        //     const getPreferredTheme = () => {
-        //         const storedTheme = getStoredTheme()
-        //         if (storedTheme) {
-        //             return storedTheme
-        //         }
-
-        //         return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-        //     }
-
-        //     const setTheme = theme => {
-        //         if (theme === 'auto') {
-        //             document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
-        //         } else {
-        //             document.documentElement.setAttribute('data-bs-theme', theme)
-        //         }
-        //     }
-
-        //     setTheme(getPreferredTheme())
-
-        //     const showActiveTheme = (theme, focus = false) => {
-        //         const themeSwitcher = document.querySelector('#bd-theme')
-
-        //         if (!themeSwitcher) {
-        //             return
-        //         }
-
-        //         const themeSwitcherText = document.querySelector('#bd-theme-text')
-        //         const activeThemeIcon = document.querySelector('.theme-icon-active use')
-        //         const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
-        //         const svgOfActiveBtn = btnToActive.querySelector('svg use').getAttribute('href')
-
-        //         document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
-        //             element.classList.remove('active')
-        //             element.setAttribute('aria-pressed', 'false')
-        //         })
-
-        //         btnToActive.classList.add('active')
-        //         btnToActive.setAttribute('aria-pressed', 'true')
-        //         activeThemeIcon.setAttribute('href', svgOfActiveBtn)
-        //         const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
-        //         themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
-
-        //         if (focus) {
-        //             themeSwitcher.focus()
-        //         }
-        //     }
-
-        //     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-        //         const storedTheme = getStoredTheme()
-        //         if (storedTheme !== 'light' && storedTheme !== 'dark') {
-        //             setTheme(getPreferredTheme())
-        //         }
-        //     })
-
-        //     window.addEventListener('DOMContentLoaded', () => {
-        //         showActiveTheme(getPreferredTheme())
-
-        //         document.querySelectorAll('[data-bs-theme-value]')
-        //             .forEach(toggle => {
-        //                 toggle.addEventListener('click', () => {
-        //                     const theme = toggle.getAttribute('data-bs-theme-value')
-        //                     setStoredTheme(theme)
-        //                     setTheme(theme)
-        //                     showActiveTheme(theme, true)
-        //                 })
-        //             })
-        //     })
-        // })()
     </script>
 
 </body>


### PR DESCRIPTION
-Added js ternary operator for theme switching along with attribute for theme switching in body tag in app razor. -Replaced SwitchTheme method in GridLayout page with a method without parameters and with one single js call inside. -Replaced js drop down for themeswitching in GridLayout page with a switch/toggle